### PR TITLE
fix: remove prompt url encode

### DIFF
--- a/gobard.go
+++ b/gobard.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -103,8 +102,6 @@ func New(cookie string) *Bard {
 
 // Ask asks a question to bard.google.com.
 func (b *Bard) Ask(prompt string) error {
-	prompt = url.QueryEscape(prompt)
-
 	b.createRestClient()
 
 	// Prepare request


### PR DESCRIPTION
Add Japanese support.

If encode the prompt, the title in bard.google.com is encoded characters, like `%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF`, and the answer is based on the encoded content.

If not encode, the title and content are correct.